### PR TITLE
Faster rewrite in Skelet1.

### DIFF
--- a/BusyCoq/Skelet1.v
+++ b/BusyCoq/Skelet1.v
@@ -179,7 +179,7 @@ Proof.
   follow rule_P_Dx. follow rule_P_xn.
   rewrite (lpow_S 3075). autorewrite with tape_post.
   follow rule_P_Dx. follow rule_P_xn.
-  rewrite (lpow_S 1537). autorewrite with tape_post.
+  rewrite (lpow_S 1537 x). autorewrite with tape_post.
   follow rule_P_Dx. follow rule_P_xn.
   unfold Hl. autorewrite with tape_post.
   finish.


### PR DESCRIPTION
We make explicit the pattern so that it quickly finds the right subterm to rewrite. On my machine this reduces the runtime of that line from 22s to virtually zero.